### PR TITLE
Pass through the desired count

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,6 +34,7 @@ module "service" {
   vpc_id          = "${var.platform_config["vpc"]}"
   container_name  = "${lookup(var.release, "component")}"
   container_port  = "${var.port}"
+  desired_count   = "${var.desired_count}"
 }
 
 module "taskdef" {

--- a/variables.tf
+++ b/variables.tf
@@ -71,3 +71,9 @@ variable "alb_listener_rule_priority" {
   type        = "string"
   description = "The priority for the rule - must be different per rule."
 }
+
+variable "desired_count" {
+  description = "The number of instances of the task definition to place and keep running."
+  type        = "string"
+  default     = "3"
+}


### PR DESCRIPTION
This is required for the primary-issuance-indexer-service, which sets
the desired count in aslive.