### PR TITLE
Removing -subscriber and -admin from dns name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ module "dns" {
   source = "github.com/mergermarket/tf_route53_dns"
 
   domain = "${var.dns_domain}"
-  name   = "${replace("${lookup(var.release, "component")}", "/-service$/", "")}"
+  name   = "${replace("${lookup(var.release, "component")}", "/-service$|-admin$|-subscriber$/", "")}"
   env    = "${var.env}"
   target = "${var.alb_dns_name}"
 }


### PR DESCRIPTION
We have a convention where this should not appear in the DNS name for a
service.

JIRA: PLAT-1141