### PR TITLE
Prevent dns destroy by default

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,11 @@
 module "dns" {
   source = "github.com/mergermarket/tf_route53_dns"
 
-  domain = "${var.dns_domain}"
-  name   = "${var.dns_name != "" ? var.dns_name : replace("${lookup(var.release, "component")}", "/-service$/", "")}"
-  env    = "${var.env}"
-  target = "${var.alb_dns_name}"
+  domain          = "${var.dns_domain}"
+  name            = "${var.dns_name != "" ? var.dns_name : replace("${lookup(var.release, "component")}", "/-service$/", "")}"
+  env             = "${var.env}"
+  target          = "${var.alb_dns_name}"
+  prevent_destroy = "${var.prevent_dns_destroy}"
 }
 
 module "listener_rule_home" {
@@ -53,7 +54,7 @@ module "service_container_definition" {
   memory         = "${var.memory}"
   container_port = "${var.port}"
 
-  container_env  = "${merge(
+  container_env = "${merge(
     map(
       "LOGSPOUT_CLOUDWATCHLOGS_LOG_GROUP_STDOUT", "${var.env}-${lookup(var.release, "component")}-stdout",
       "LOGSPOUT_CLOUDWATCHLOGS_LOG_GROUP_STDERR", "${var.env}-${lookup(var.release, "component")}-stderr",

--- a/variables.tf
+++ b/variables.tf
@@ -89,3 +89,8 @@ variable "logentries_token" {
   type        = "string"
   default     = ""
 }
+
+variable "prevent_dns_destroy" {
+  type    = "string"
+  default = "true"
+}


### PR DESCRIPTION
This is to protect against accidentally pushing a pipeline that removes
the DNS before it has been removed from state, as we move over to
tf_ecs_service.