### PR TITLE
Add extra parameters, passed to ECS service module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -28,13 +28,20 @@ module "ecs_update_monitor" {
 module "service" {
   source = "github.com/mergermarket/tf_load_balanced_ecs_service"
 
-  name            = "${var.env}-${lookup(var.release, "component")}"
-  cluster         = "${var.ecs_cluster}"
-  task_definition = "${module.taskdef.arn}"
-  vpc_id          = "${var.platform_config["vpc"]}"
-  container_name  = "${lookup(var.release, "component")}"
-  container_port  = "${var.port}"
-  desired_count   = "${var.desired_count}"
+  name                             = "${var.env}-${lookup(var.release, "component")}"
+  cluster                          = "${var.ecs_cluster}"
+  task_definition                  = "${module.taskdef.arn}"
+  vpc_id                           = "${var.platform_config["vpc"]}"
+  container_name                   = "${lookup(var.release, "component")}"
+  container_port                   = "${var.port}"
+  desired_count                    = "${var.desired_count}"
+  deregistration_delay             = "${var.deregistration_delay}"
+  health_check_interval            = "${var.health_check_interval}"
+  health_check_path                = "${var.health_check_path}"
+  health_check_timeout             = "${var.health_check_timeout}"
+  health_check_healthy_threshold   = "${var.health_check_healthy_threshold}"
+  health_check_unhealthy_threshold = "${var.health_check_unhealthy_threshold}"
+  health_check_matcher             = "${var.health_check_matcher}"
 }
 
 module "taskdef" {

--- a/variables.tf
+++ b/variables.tf
@@ -89,3 +89,45 @@ variable "logentries_token" {
   type        = "string"
   default     = ""
 }
+
+variable "deregistration_delay" {
+  description = "The amount time for Elastic Load Balancing to wait before changing the state of a deregistering target from draining to unused. The range is 0-3600 seconds."
+  type        = "string"
+  default     = "10"
+}
+
+variable "health_check_interval" {
+  description = "The approximate amount of time, in seconds, between health checks of an individual target. Minimum value 5 seconds, Maximum value 300 seconds."
+  type        = "string"
+  default     = "5"
+}
+
+variable "health_check_path" {
+  description = "The destination for the health check request."
+  type        = "string"
+  default     = "/internal/healthcheck"
+}
+
+variable "health_check_timeout" {
+  description = "The amount of time, in seconds, during which no response means a failed health check."
+  type        = "string"
+  default     = "4"
+}
+
+variable "health_check_healthy_threshold" {
+  description = "The number of consecutive health checks successes required before considering an unhealthy target healthy."
+  type        = "string"
+  default     = "2"
+}
+
+variable "health_check_unhealthy_threshold" {
+  description = "The number of consecutive health check failures required before considering the target unhealthy."
+  type        = "string"
+  default     = "2"
+}
+
+variable "health_check_matcher" {
+  description = "The HTTP codes to use when checking for a successful response from a target. You can specify multiple values (for example, \"200,202\") or a range of values (for example, \"200-299\")."
+  type        = "string"
+  default     = "200-299"
+}


### PR DESCRIPTION
The module defining the ECS service allows for configuring the healthcheck parameters but these aren't exposed to users of this module.

This adds them into the parameters of this module so that they can be configured.