### PR TITLE
[CRUB-373] add "task_role_arn" and pass it down to taskdef module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -49,6 +49,7 @@ module "taskdef" {
 
   family                = "${var.env}-${lookup(var.release, "component")}"
   container_definitions = ["${module.service_container_definition.rendered}"]
+  task_role_arn         = "${var.task_role_arn}"
 }
 
 module "service_container_definition" {

--- a/variables.tf
+++ b/variables.tf
@@ -131,3 +131,9 @@ variable "health_check_matcher" {
   type        = "string"
   default     = "200-299"
 }
+
+variable "task_role_arn" {
+  description = "The Amazon Resource Name for an IAM role for the task"
+  type        = "string"
+  default     = ""
+}


### PR DESCRIPTION
To be able to assign policies to inner tasks (to enable them to access SQS queues for example) we need to be able to pass `task_role_arn` through `tf_ecs_backend_service` to `tf_ecs_task_definition`